### PR TITLE
Don't re-run broker, proxy-go, and tor client-0 with every `script.sh --client`

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -41,12 +41,7 @@ if [ "$build" -ne "0" ]; then
     cd /go/src
 fi
 
-if [ "$client" -eq "0" ]; then
-    cp snowflake.git/broker/broker /go/bin/
-    cp snowflake.git/proxy-go/proxy-go /go/bin/
-    cp snowflake.git/client/client /go/bin/
-    cp snowflake.git/client/torrc-localhost /go/bin
-else
+if [ "$client" -ne "0" ]; then
     cd /go/bin
 
     # Find a SOCKSPort to bind to that is not in use
@@ -66,6 +61,11 @@ else
 
     exit
 fi
+
+cp snowflake.git/broker/broker /go/bin/
+cp snowflake.git/proxy-go/proxy-go /go/bin/
+cp snowflake.git/client/client /go/bin/
+cp snowflake.git/client/torrc-localhost /go/bin
 
 cd /go/bin
 

--- a/script.sh
+++ b/script.sh
@@ -63,6 +63,8 @@ else
     echo "SOCKSPort $(($count+9050))" >> torrc-$count
 
     nohup tor -f torrc-$count > client-$count.log 2> client-$count.err &
+
+    exit
 fi
 
 cd /go/bin


### PR DESCRIPTION
These were being re-run every time, which was mostly harmless because broker and tor client-0 would immediately exit with a failure to bind a port, and proxy-go would just start another instance. Error messages such as
```
listen tcp :8080: bind: address already in use
```
were hidden because the original .log and .err files were still held open, but if you removed the `>` and `2>` output redirections, the error messages would show up in nohup.out.